### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-waste-sorter.svg?branch=master)](https://travis-ci.org/IBM/watson-waste-sorter)
-![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/a9da622b1e6fbfdc883c6a1c0ca2e171/badge.svg)
 
 # Create a custom Visual Recognition classifier for sorting waste
 
@@ -51,7 +50,7 @@ Then, go to the [IBM Cloud Dashboard](https://console.bluemix.net/dashboard/apps
 server application's endpoint. Once you done that, you can move on to [Step 3](#3-create-the-mobile-application-and-connect-it-to-the-server)
 and deploy your mobile application.
 
-[![Deploy to IBM Cloud](https://metrics-tracker.mybluemix.net/stats/a9da622b1e6fbfdc883c6a1c0ca2e171/button.svg)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM/watson-waste-sorter)
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM/watson-waste-sorter)
 
 ## 1. Create your custom visual recognition model
 
@@ -148,29 +147,6 @@ waste is too far. In that case just simply point your camera closer and retake a
 # Troubleshooting
 
 * To clean up, simply delete your mobile app. Then you can delete your server application via the [IBM Cloud Dashboard](https://console.bluemix.net/dashboard/apps/).
-
-## Privacy Notice
-
-If using the Deploy to IBM Cloud button some metrics are tracked, the following information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
-
-* Python package version
-* Python repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`) or OS username
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Cloud Foundry API (`cf_api`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-* Metadata in the repository.yaml file
-
-This data is collected from the `setup.py` and `repository.yaml` file in the sample application and the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
-
-## Disabling Deployment Tracking
-
-To disable tracking, simply remove ``metrics_tracker_client.track()`` from the ``run.py`` file in the server directory.
 
 # Links
 * [Demo on Youtube](https://youtu.be/0yWE8eClrxU)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,3 @@
 Flask>=0.12
 requests>=2.18
 watson-developer-cloud>=1.0.2
-metrics-tracker-client>=1.1.1

--- a/server/run.py
+++ b/server/run.py
@@ -4,7 +4,6 @@ import logging
 from flask import Flask, request
 from watson_developer_cloud import VisualRecognitionV3
 from watson_developer_cloud import watson_service
-import metrics_tracker_client
 
 app = Flask(__name__, static_url_path='')
 app.config['PROPAGATE_EXCEPTIONS'] = True
@@ -94,5 +93,4 @@ if __name__ == "__main__":
         'watson_vision_combined')
     apikey = visual_creds['api_key']
     classifier_id = set_classifier()
-    metrics_tracker_client.track()
     app.run(host='0.0.0.0', port=int(port))


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
`metrics_tracker_client.track()`
reference in requirements.txt

Change D2B to:
https://bluemix.net/deploy/button.png